### PR TITLE
update docker link to public repository url

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -59,7 +59,7 @@ export default {
   data() {
     return {
       appStoreUrl: 'https://testflight.apple.com/join/wiic7QIW',
-      dockerHubUrl: 'https://hub.docker.com/repository/docker/advplyr/audiobookshelf',
+      dockerHubUrl: 'https://hub.docker.com/r/advplyr/audiobookshelf',
       playStoreUrl: 'https://play.google.com/store/apps/details?id=com.audiobookshelf.app',
       githubUrl: 'https://github.com/advplyr/audiobookshelf',
       discordUrl: 'https://discord.gg/pJsjuNCKRq'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -60,7 +60,7 @@ export default {
       showBooks: false,
       showInstall: false,
       appStoreUrl: 'https://testflight.apple.com/join/wiic7QIW',
-      dockerHubUrl: 'https://hub.docker.com/repository/docker/advplyr/audiobookshelf',
+      dockerHubUrl: 'https://hub.docker.com/r/advplyr/audiobookshelf',
       playStoreUrl: 'https://play.google.com/store/apps/details?id=com.audiobookshelf.app',
       githubUrl: 'https://github.com/advplyr/audiobookshelf',
       discordUrl: 'https://discord.gg/pJsjuNCKRq',


### PR DESCRIPTION
With the current url only the owners of the repository can see it, all others are stopped at the login prompt of the docker hub site.
Changing the url to the public repository site, so that everyone can access it (and new users are not deterred before they even tried the project 🥳).