### PR TITLE
Update Debian Install Instructions

### DIFF
--- a/content/docs/install/3.linux-install.md
+++ b/content/docs/install/3.linux-install.md
@@ -1,8 +1,8 @@
 ---
-title: Linux
+title: Linux (Debian, Ubuntu, …)
 category: Install
-slug: 3.linux-install
-hash: "#linux-install"
+slug: 3.linux-install-deb
+hash: "#linux-install-deb"
 fullpath: /docs
 ---
 
@@ -22,11 +22,13 @@ PORT=13378
 ## PPA Install (recommended)
 
 ```bash
-curl -s --compressed "https://advplyr.github.io/audiobookshelf-ppa/KEY.gpg" | sudo apt-key add - 
+sudo apt install gnupg curl
 
-sudo curl -s --compressed -o /etc/apt/sources.list.d/audiobookshelf.list "https://advplyr.github.io/audiobookshelf-ppa/audiobookshelf.list" 
+curl -s --compressed "https://advplyr.github.io/audiobookshelf-ppa/KEY.gpg" | sudo apt-key add -
 
-sudo apt update 
+sudo curl -s --compressed -o /etc/apt/sources.list.d/audiobookshelf.list "https://advplyr.github.io/audiobookshelf-ppa/audiobookshelf.list"
+
+sudo apt update
 
 sudo apt install audiobookshelf
 ```


### PR DESCRIPTION
This patch updates the installation instructions for Debian based linux distributions. In particular this:

- Makes it clear that the current linux instructions are for Debian based distributions like Ubuntu or Debian and not for something like CentOS or Arch.
- Adds installation instructions for some tools required for executing the following instructions.