### PR TITLE
Fix HTML Encoding

### DIFF
--- a/content/docs/install/1.docker-install.md
+++ b/content/docs/install/1.docker-install.md
@@ -13,10 +13,10 @@ docker run -d \
   -e AUDIOBOOKSHELF_UID=99 \
   -e AUDIOBOOKSHELF_GID=100 \
   -p 13378:80 \
-  -v &lt;/path/to/config>:/config \
-  -v &lt;/path/to/metadata>:/metadata \
-  -v &lt;/path/to/audiobooks>:/audiobooks \
-  -v &lt;/path/to/podcasts>:/podcasts \
+  -v </path/to/config>:/config \
+  -v </path/to/metadata>:/metadata \
+  -v </path/to/audiobooks>:/audiobooks \
+  -v </path/to/podcasts>:/podcasts \
   --name audiobookshelf \
   --rm ghcr.io/advplyr/audiobookshelf
 ```

--- a/content/docs/install/2.docker-compose-install.md
+++ b/content/docs/install/2.docker-compose-install.md
@@ -17,10 +17,10 @@ services:
     ports:
       - 13378:80
     volumes:
-      - &lt;/path/to/audiobooks>:/audiobooks
-      - &lt;/path/to/podcasts>:/podcasts
-      - &lt;/path/to/config>:/config
-      - &lt;/path/to/metadata>:/metadata
+      - </path/to/audiobooks>:/audiobooks
+      - </path/to/podcasts>:/podcasts
+      - </path/to/config>:/config
+      - </path/to/metadata>:/metadata
 ```
 
   > 


### PR DESCRIPTION
This patch fixes several occurrences of `<` being double encoded and therefor shown in the encoded form in the rendered docs like this:

```
  -v &lt;/path/to/config>:/config \
  -v &lt;/path/to/metadata>:/metadata \
  -v &lt;/path/to/audiobooks>:/audiobooks \
```