### PR TITLE
Don't use “here” links

### DIFF
--- a/content/docs/0.introduction.md
+++ b/content/docs/0.introduction.md
@@ -10,4 +10,4 @@ Audiobookshelf works best when you have an organized directory structure like sh
 
 Join our [Discord server](https://discord.gg/pJsjuNCKRq) or [Matrix space](https://matrix.to/#/#audiobookshelf:matrix.org).
 
-API documentation can be found [here](https://api.audiobookshelf.org/).
+If you are interested in integrating with Audiobookshelf, visit the [API documentation](https://api.audiobookshelf.org/).

--- a/content/docs/install/4.windows-install.md
+++ b/content/docs/install/4.windows-install.md
@@ -8,8 +8,6 @@ fullpath: /docs
 
 **Windows installer is not yet available.** However...
 
-You can install audiobookshelf on Windows using Docker. Check out [this](/guides/docker-install) user-contributed guide for installing on Windows and join our Discord/Matrix server for support.
+You can install audiobookshelf on Windows using Docker. Check out the [user-contributed guide for installing on Windows](/guides/docker-install) and join our Discord/Matrix server for support.
 
-  > 
-  > **We are looking for a .NET developer familiar with building Windows installers to help!**
-  > 
+> **We are looking for a .NET developer familiar with building Windows installers to help!**


### PR DESCRIPTION
This patch removes “this” and “here” links, replacing them with a functional description of where these links lead.

If you are interested why it's not a good idea to use “here” links, let me recommend the article [Don’t use “click here” …and other common hyperlink mistakes](https://heyoka.medium.com/dont-use-click-here-f32f445d1021).