### PR TITLE
Added things about docker as a snap and volumes

### DIFF
--- a/content/docs/install/1.docker-install.md
+++ b/content/docs/install/1.docker-install.md
@@ -27,12 +27,6 @@ docker run -d \
   > <small class="text-error block">\* Windows users will need to remove the \ and run this as a single line</small>
   > 
 
-**Docker on Ubuntu caution**
-
-If you are installing audiobookshelf in a docker container on Linux, there are some limitations to be aware of.
-  
-    If you are running Docker as a snap on Linux, you must host your content under /home
-    You will get terriblly misleading errors if you try to put them anywhere else, making it look like the device you are trying to use is read only when you go to start the container
 
 **Volume mappings**
 
@@ -41,11 +35,16 @@ If you are installing audiobookshelf in a docker container on Linux, there are s
 - Map any other directories you want to use for your book and podcast collections (ebooks supported as experimental)
 - If you are using Docker as noted above on Linux, you cannot put the volumes anywhere except under /home
 
-**Putting volumes on a second device**
+**Docker installed as a snap on Ubuntu caution**
 
-In order to add a device to put your audio books on, if Docker is installed as a snap, one approach would be as follows.
-- Create the user account and home directory
-- Mount the new partition on the users home directory 
-- Proceed with the docker run command from above
+If you are installing audiobookshelf in a docker container on Linux and docker is installed as a snap, there is one particular limitation. 
+  
+    If you are running Docker as a snap on Linux, this build can only access files in the home directory. 
+    You will get terriblly misleading errors if you try to put them anywhere else, making it look like the device you are trying to use is read only when you go to start the container
+
+    One approach to work with that limitation would be to add a new mount for the audiobookshelf user home directory.
+    - Create the user account and home directory
+    - Mount the new partition on the users home directory 
+    - Proceed with the installation as usual
 
 

--- a/content/docs/install/1.docker-install.md
+++ b/content/docs/install/1.docker-install.md
@@ -5,7 +5,7 @@ slug: 1.docker-install
 hash: "#docker-install"
 fullpath: /docs
 ---
-
+Before you install audiobookshelf you must create a user account, the UID and GID of that account and it's group will be used in the docker run command below. 
 ```bash
 docker pull ghcr.io/advplyr/audiobookshelf
 
@@ -27,8 +27,25 @@ docker run -d \
   > <small class="text-error block">\* Windows users will need to remove the \ and run this as a single line</small>
   > 
 
+**Docker on Ubuntu caution**
+
+If you are installing audiobookshelf in a docker container on Linux, there are some limitations to be aware of.
+  
+    If you are running Docker as a snap on Linux, you must host your content under /home
+    You will get terriblly misleading errors if you try to put them anywhere else, making it look like the device you are trying to use is read only when you go to start the container
+
 **Volume mappings**
+
 - /config will contain the database (users/books/libraries/settings)
 - /metadata will contain cache, streams, covers, downloads, backups and logs
 - Map any other directories you want to use for your book and podcast collections (ebooks supported as experimental)
+- If you are using Docker as noted above on Linux, you cannot put the volumes anywhere except under /home
+
+**Putting volumes on a second device**
+
+In order to add a device to put your audio books on, if Docker is installed as a snap, one approach would be as follows.
+- Create the user account and home directory
+- Mount the new partition on the users home directory 
+- Proceed with the docker run command from above
+
 


### PR DESCRIPTION
Simple updates to the docker page, accounting mostly for when docker is run as a snap on ubuntu.  Volumes are particularly annoying in this case, but I figured out a way around those limitations. 