### PR TITLE
Fix Nixos installation instructions

### DIFF
--- a/content/docs/install/5.linux-install-nix.md
+++ b/content/docs/install/5.linux-install-nix.md
@@ -50,10 +50,17 @@ You can create a simple systemd service in your `configuration.nix` to automatic
 audiobookshelf after a reboot.
 
 ```nix
+let datadir = "/var/lib/audiobookshelf";
+in
 {
   users = {
     groups.audiobookshelf.members = [ "audiobookshelf" ];
-    users.audiobookshelf.isSystemUser = true;
+    users.audiobookshelf = {
+      isSystemUser = true;
+      createHome = true;
+      home = datadir;
+      group = "audiobookshelf";
+    };
   };
 
   systemd.services.audiobookshelf = with pkgs; {
@@ -61,9 +68,8 @@ audiobookshelf after a reboot.
     description = "Self-hosted audiobook server for managing and playing audiobooks";
     serviceConfig = {
       Type = "simple";
-      WorkingDirectory = "/usr/share/audiobookshelf";
-      ExecStart = "${audiobookshelf}/bin/audiobookshelf --host 127.0.0.1 --port 8000"
-      ExecReload = "${util-linux}/bin/kill -HUP $MAINPID";
+      WorkingDirectory = datadir;
+      ExecStart = "${audiobookshelf}/bin/audiobookshelf --host 127.0.0.1 --port 8000";
       Restart = "always";
       User = "audiobookshelf";
       Group = "audiobookshelf";
@@ -73,9 +79,6 @@ audiobookshelf after a reboot.
   };
 }
 ```
-
-You can create a simple SystemD service to automatically start audiobookshelf after a reboot.
-Write a file `audiobookshelf.service` to `/etc/systemd/system/` with the following contents:
 
 To run Audiobookshelf and ensure it will be started automatically after a reboot, run:
 

--- a/content/docs/install/5.linux-install-nix.md
+++ b/content/docs/install/5.linux-install-nix.md
@@ -9,7 +9,7 @@ order: 1.5
 <div class=warn>
 <ul>
 <li>This installation method is still in testing.</li>
-<li>Only in the nixos-unstable channel for now</li>
+<li>The module and the package are only available in the nixos-unstable channel currently, but will be added in the 23.11 release.</li>
 </ul>
 </div>
 
@@ -47,44 +47,26 @@ In this case set `--host 127.0.0.1` instead.
 ## Start Audiobookshelf
 
 You can create a simple systemd service in your `configuration.nix` to automatically start
-audiobookshelf after a reboot.
+audiobookshelf:
 
 ```nix
-let datadir = "/var/lib/audiobookshelf";
-in
-{
-  users = {
-    groups.audiobookshelf.members = [ "audiobookshelf" ];
-    users.audiobookshelf = {
-      isSystemUser = true;
-      createHome = true;
-      home = datadir;
-      group = "audiobookshelf";
-    };
-  };
-
-  systemd.services.audiobookshelf = with pkgs; {
-    enable = true;
-    description = "Self-hosted audiobook server for managing and playing audiobooks";
-    serviceConfig = {
-      Type = "simple";
-      WorkingDirectory = datadir;
-      ExecStart = "${audiobookshelf}/bin/audiobookshelf --host 127.0.0.1 --port 8000";
-      Restart = "always";
-      User = "audiobookshelf";
-      Group = "audiobookshelf";
-    };
-    wantedBy = [ "multi-user.target" ];
-    requires = [ "network.target" ];
-  };
-}
+services.audiobookshelf {
+  enable = true;
+  port = 8234;
+};
 ```
+For further options, see [the NixOS options page](https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=services.audiobookshelf).
 
-To run Audiobookshelf and ensure it will be started automatically after a reboot, run:
-
-```bash
-systemctl start audiobookshelf.service
-systemctl enable audiobookshelf.service
+To configure a reverse nginx proxy, add the following:
+```nix
+services.nginx = {
+  enable = true;
+  virtualHosts."your.hostname.org" = {
+    locations."/" = {
+      proxyPass = "http://localhost:8234/";
+    };
+  };
+};
 ```
 
 To check the current status of the service, run:


### PR DESCRIPTION
I tried to install audiobookshelf as a service locally and ran into some trouble. I was able to fix them and wanted to share the fix here.

## Changes

* Remove outdated part about a manual service file
* Remove unrecommended and unnecessary ExecReload option
* Fixes the data directory
* Fixes the audiobookshelf system user setup

After the changes I could launch the website locally, create a root user and log in. I didn't test adding any podcasts yet, will do that as soon as I figured out how one creates podcasts.

## Comment

I also recommend to _remove_ the section `Imperative installation` in this file. It's not considered good style these days anymore.