### PR TITLE
Update 3.inux-install-deb.md

### DIFF
--- a/content/docs/install/3.inux-install-deb.md
+++ b/content/docs/install/3.inux-install-deb.md
@@ -16,7 +16,7 @@ Activate the repository:
 
 ```bash
 sudo apt install gnupg curl
-curl -s https://advplyr.github.io/audiobookshelf-ppa/KEY.gpg | sudo apt-key add -
+wget -O- https://advplyr.github.io/audiobookshelf-ppa/KEY.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/adb-archive-keyring.gpg
 sudo curl -s -o /etc/apt/sources.list.d/audiobookshelf.list https://advplyr.github.io/audiobookshelf-ppa/audiobookshelf.list
 ```
 


### PR DESCRIPTION
Command apt-key is obsolete from Debian 11/bullseye (https://manpages.debian.org/bullseye/apt/apt-key.8.en.html) and Ubuntu 22.04/jammy (https://manpages.ubuntu.com/manpages/jammy/en/man8/apt-key.8.html).