### PR TITLE
Add Audiobookshelf Deployment in Kubernetes Documentation

### DIFF
--- a/content/docs/install/11.kubernetes.md
+++ b/content/docs/install/11.kubernetes.md
@@ -1,3 +1,11 @@
+---
+title: Kubernetes
+category: Install
+hash: "#Kubernetes"
+fullpath: /docs
+order: 1.92
+---
+
 # Audiobookshelf Deployment in Kubernetes
 
 ## Prerequisites

--- a/content/docs/install/11.kubernetes.md
+++ b/content/docs/install/11.kubernetes.md
@@ -40,7 +40,10 @@ kubectl apply -f cluster-issuer.yaml
 ## Create Namespace for Audiobookshelf
 First, create a dedicated namespace for Audiobookshelf:
 ```yaml
-apiversion: v1kind: Namespacemetadata:  name: audiobookshelf-ns
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: audiobookshelf-ns
 ```
 Apply the namespace with:
 ```bash
@@ -63,4 +66,92 @@ spec:
       port: 80
       targetPort: 80
   type: ClusterIP  # Exposes the service only inside the cluster
+```
+### 2. Audiobookshelf Ingress
+Configures access to the Audiobookshelf service via a domain name and sets up TLS encryption:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: audiobookshelf-ingress
+  namespace: audiobookshelf-ns
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production  # Refers to the Let's Encrypt ClusterIssuer
+    acme.cert-manager.io/http01-ingress-class: public  # Specifies the ingress class
+    nginx.ingress.kubernetes.io/rewrite-target: /  # Rewrites the URL to the service
+    nginx.ingress.kubernetes.io/proxy-body-size: 2048m  # Sets the maximum allowed request body size
+spec:
+  rules:
+  - host: audiobooks.example.com  # Replace with your domain
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: audiobookshelf  # The service to route traffic to
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - audiobooks.example.com  # Replace with your domain
+    secretName: audiobookshelf-tls  # Secret created by Cert-Manager
+```
+### 3. Audiobookshelf Deployment
+Deploys the Audiobookshelf application with volume mounts for storing audiobooks, podcasts, and configuration files:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: audiobookshelf  # Matches the Service selector
+  template:
+    metadata:
+      labels:
+        app: audiobookshelf  # Matches the Deployment selector
+    spec:
+      containers:
+      - name: audiobookshelf
+        image: ghcr.io/advplyr/audiobookshelf:latest  # Audiobookshelf container image
+        ports:
+        - containerPort: 80  # Exposes port 80 for the application
+        volumeMounts:
+        - name: audiobooks-volume
+          mountPath: /audiobooks  # Mounts the audiobooks directory inside the container
+        - name: podcasts-volume
+          mountPath: /podcasts  # Mounts the podcasts directory inside the container
+        - name: config-volume
+          mountPath: /config  # Mounts the configuration directory inside the container
+        - name: metadata-volume
+          mountPath: /metadata  # Mounts the metadata directory inside the container
+      volumes:
+      - name: audiobooks-volume
+        hostPath:
+          path: /YOUR_PATH/audiobooks/  # Path on the host for audiobooks
+      - name: podcasts-volume
+        hostPath:
+          path: /YOUR_PATH//podcasts  # Path on the host for podcasts
+      - name: config-volume
+        hostPath:
+          path: /YOUR_PATH//audiobookshelf  # Path on the host for configuration files
+      - name: metadata-volume
+        hostPath:
+          path: /YOUR_PATH/metadata  # Path on the host for metadata
+```
+Apply the full manifest:
+```bash
+kubectl apply -f audiobookshelf-manifest.yaml
+```
+Verify that the services, ingress, and deployment are running:
+```bash
+kubectl get all -n audiobookshelf-ns
+kubectl describe ingress audiobookshelf-ingress -n audiobookshelf-ns
+
 ```

--- a/content/docs/install/11.kubernetes.md
+++ b/content/docs/install/11.kubernetes.md
@@ -1,0 +1,66 @@
+# Audiobookshelf Deployment in Kubernetes
+
+## Prerequisites
+
+1. **Kubernetes Cluster**
+   Ensure you have a Kubernetes cluster running. This deployment assumes you're using **nginx** as the ingress controller.
+
+2. **Ingress Controller (NGINX)**
+   Make sure NGINX ingress controller is installed and configured on your cluster. If you don't have it installed yet, you can follow the [official NGINX ingress controller installation guide](https://kubernetes.github.io/ingress-nginx/deploy/).
+
+3. **Cluster Issuer for Let's Encrypt**
+   You need a **ClusterIssuer** to automatically manage TLS certificates using Let's Encrypt. Below is an example configuration to create a ClusterIssuer:
+
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: ClusterIssuer
+   metadata:
+     name: letsencrypt-production
+   spec:
+     acme:
+       server: https://acme-v02.api.letsencrypt.org/directory
+       email: your-email@example.com  # Replace with your email
+       privateKeySecretRef:
+         name: letsencrypt-production-key
+       solvers:
+       - http01:
+           ingress:
+             class: nginx
+
+* Replace your-email@example.com with your own email address.
+* This will use HTTP-01 challenge for certificate issuance, with NGINX managing the ingress.
+
+Apply this YAML to your cluster using:
+
+```bash
+kubectl apply -f cluster-issuer.yaml
+```
+4. **Subdomain Setup (Optional)** If you want to use a subdomain, set up your DNS records to point to your Kubernetes cluster. In this case, I am using OVH as my DNS provider. Create an A record for your subdomain pointing to your cluster’s IP address.
+
+## Create Namespace for Audiobookshelf
+First, create a dedicated namespace for Audiobookshelf:
+```yaml
+apiversion: v1kind: Namespacemetadata:  name: audiobookshelf-ns
+```
+Apply the namespace with:
+```bash
+kubectl apply -f namespace.yaml
+```
+## Audiobookshelf Kubernetes Deployment
+### 1. Audiobookshelf Service
+Defines a service that exposes the Audiobookshelf application within the cluster:
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf-ns
+spec:
+  selector:
+    app: audiobookshelf  # Matches the label from the Deployment
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP  # Exposes the service only inside the cluster
+```

--- a/content/docs/install/11.kubernetes.md
+++ b/content/docs/install/11.kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes
 category: Install
-hash: "#Kubernetes"
+hash: "#kubernetes"
 fullpath: /docs
 order: 1.92
 ---


### PR DESCRIPTION
### Pull Request Description:
This PR adds documentation for deploying Audiobookshelf in a Kubernetes cluster using NGINX as the ingress controller and Let's Encrypt for certificate management. The following are included in this update:

- **Prerequisites** section to guide users on setting up the Kubernetes cluster, NGINX ingress controller, and Let's Encrypt ClusterIssuer.
- **Namespace creation** for the Audiobookshelf deployment.
- **Kubernetes manifest** for the Audiobookshelf Service, Ingress, and Deployment, including necessary volumes for audiobooks, podcasts, config, and metadata storage.
- Instructions on how to apply the manifests and verify the deployment in Kubernetes.

This documentation ensures that users can easily deploy Audiobookshelf in a Kubernetes environment with automated TLS certificates using Cert-Manager and Let's Encrypt.