### PR TITLE
Add ARD-Audiothek metadata provider details

### DIFF
--- a/content/guides/13.custom-metadata-providers.md
+++ b/content/guides/13.custom-metadata-providers.md
@@ -37,6 +37,7 @@ If you have made a custom provider and want to share, you can [open a PR for thi
 | abs-bigfinish    | https://github.com/vito0912/abs-bigfinish          | Provides Big Finish metadata                                     |
 | abs-storytel     | https://github.com/Revisor01/abs-storytel-provider | Provides Storytel metadata                                       |
 | abs-hardcover    | https://github.com/Vito0912/hardcover-provider     | Provides Hardcover metadata                                      |
+| ARD-Audiothek    | https://github.com/h43lb1t0/ARD_Audiothek_provider | Provides metadata for Audiobooks and Podcasts from the ARD Audiothek (Service of the public broadcasters in Germany) |
 
 ## Community hosted providers
 


### PR DESCRIPTION
Added a custom provider for the [ARD Audiothek](https://www.ardaudiothek.de/) to the list of community providers in custom-metadata-providers.md.