### PR TITLE
removing Toutui from third app list

### DIFF
--- a/content/faq/3.app.md
+++ b/content/faq/3.app.md
@@ -89,7 +89,7 @@ Any issues with the apps should be directed to the app maintainers through appro
 | Android                      | Lissen      | https://github.com/GrakovNe/lissen-android | Lissen is a free, aesthetic Audiobookshelf client designed especially for seamless audiobook listening                                                                                                      |
 | Android, Windows, Linux, Web | Buchable    | https://github.com/Vito0912/abs_flutter    | A feature-rich, cross-platform Audiobookshelf client offering extensive functionality, including support for audiobooks, podcasts, caching and more.                                                        |
 | HarmonyOS                    | Harmshelf   | https://github.com/shanyan-wcx/Harmshelf   | A native Audiobookshelf client for HarmonyOS, supporting mobile phones, tablets and PC/2in1                                                          |
-| Linux, macOS                 | Toutui      | https://github.com/AlbanDAVID/Toutui       | TUI client. Experience the power of ABS in your terminal!                                                                                                                                                   |
+
 
 ## I want to build a client app. What are the rules?
 


### PR DESCRIPTION
 I'm not able to properly maintain Toutui anymore. It's why I prefer to remove it from the third list app. Thx!