### PR TITLE
Add abs-ranobedb metadata provider

### DIFF
--- a/content/guides/13.custom-metadata-providers.md
+++ b/content/guides/13.custom-metadata-providers.md
@@ -38,6 +38,7 @@ If you have made a custom provider and want to share, you can [open a PR for thi
 | abs-storytel     | https://github.com/Revisor01/abs-storytel-provider | Provides Storytel metadata                                                                                                      |
 | abs-opds         | https://github.com/DeXP/abs-opds                   | OPDS books catalog (biggest russian: Flibusta, inxp-web) Note: does not provide syncing reading progress                        |
 | Abs-Ximalaya     | https://github.com/shanyan-wcx/Abs-Ximalaya        | Provides Ximalaya (喜马拉雅) metadata                                                                                            |
+| abs-ranobedb     | https://github.com/kennethsible/abs-ranobedb       | Provides RanobeDB metadata for Japanese light novels                                                                            |
 
 ## Community hosted providers
 


### PR DESCRIPTION
[RanobeDB](https://ranobedb.org/) is a database for Japanese light novels and any official translations. The current Audiobookshelf metadata providers frequently struggle with light novels. For example, Google Books often incorrectly identifies light novels as manga, assigns overly generic genres (e.g., "light novel" as the sole genre tag), and fails to recognize volume numbers as parts of a series.